### PR TITLE
Add option to disable the loading of existing secrets

### DIFF
--- a/cmd/sealedsecretsweb/handler.go
+++ b/cmd/sealedsecretsweb/handler.go
@@ -15,9 +15,11 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	data := struct {
-		OutputFormat string
+		OutputFormat       string
+		DisableLoadSecrets bool
 	}{
 		*outputFormat,
+		*disableLoadSecrets,
 	}
 
 	indexTmpl.Execute(w, data)
@@ -58,6 +60,11 @@ func sealHandler(w http.ResponseWriter, r *http.Request) {
 
 func secretsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
+		if *disableLoadSecrets {
+			http.Error(w, fmt.Sprintf("Loading secrets is disabled"), http.StatusForbidden)
+			return
+		}
+
 		// List all secrets.
 		secrets, err := sHandler.List()
 
@@ -124,6 +131,11 @@ func secretsHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write(js)
 		return
 	} else if r.Method == http.MethodPut {
+		if *disableLoadSecrets {
+			http.Error(w, fmt.Sprintf("Loading secrets is disabled"), http.StatusForbidden)
+			return
+		}
+
 		// Load existing secret.
 		data := struct {
 			Name      string `json:"name"`

--- a/cmd/sealedsecretsweb/sealedsecretsweb.go
+++ b/cmd/sealedsecretsweb/sealedsecretsweb.go
@@ -27,6 +27,7 @@ var (
 	certFile       = flag.String("cert", "", "Certificate / public key to use for encryption. Overrides --controller-*")
 	controllerNs   = flag.String("controller-namespace", metav1.NamespaceSystem, "Namespace of sealed-secrets controller.")
 	controllerName = flag.String("controller-name", "sealed-secrets-controller", "Name of sealed-secrets controller.")
+	disableLoadSecrets = flag.Bool("disable-load-secrets", false, "Disable the loading of existing secrets")
 	outputFormat   = flag.String("format", "json", "Output format for sealed secret. Either json or yaml")
 	printVersion   = flag.Bool("version", false, "Print version information and exit")
 

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
         <v-spacer></v-spacer>
         <v-btn @click="encode" text>Encode</v-btn>
         <v-btn @click="decode" text>Decode</v-btn>
-        <v-btn @click="loadSecrets" text>Secrets</v-btn>
+        {{ if eq .DisableLoadSecrets false}}<v-btn @click="loadSecrets" text>Secrets</v-btn>{{end}}
         <v-btn @click="seal" text>Seal</v-btn>
       </v-app-bar>
 
@@ -75,8 +75,8 @@
                   <v-chip color="primary">{{"{{namespace}}"}}</v-chip>
                 </v-list-item-icon>
               </v-list-item>
-            </v-card-text>
-          </v-list>
+            </v-list>
+          </v-card-text>
         </v-card>
       </v-dialog>
 


### PR DESCRIPTION
Introduce a new flag `--disable-load-secrets` to disable the loading of existing secrets. If the flag is enabled all API requests to the endpoints `loadSecrets` and `loadSecret` are forbidden and a 403 error is returned.

The `Secrets` button is not visible when the option is enabled.

![Bildschirmfoto 2020-01-28 um 19 57 20](https://user-images.githubusercontent.com/18552168/73295673-6b901e00-4208-11ea-9017-5a28b191d919.png)

To enable the option in the Helm chart the `--disable-load-secrets` flag must be set in the `args` array:

```yaml
replicaCount: 1

image:
  repository: ricoberger/sealed-secrets-web
  tag: 2.1.2
  pullPolicy: IfNotPresent
  args:
    - --disable-load-secrets

...
```

Closes #3.