### PR TITLE
Change handling of arguments

### DIFF
--- a/charts/sealed-secrets-web/Chart.yaml
+++ b/charts/sealed-secrets-web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 2.1.5
+appVersion: 2.2.0
 description: A web interface for Sealed Secrets by Bitnami.
 home: https://github.com/ricoberger/sealed-secrets-web
 icon: https://raw.githubusercontent.com/ricoberger/sealed-secrets-web/master/assets/logo.png
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: sealed-secrets-web
-version: 2.1.5
+version: 2.2.0

--- a/charts/sealed-secrets-web/values.yaml
+++ b/charts/sealed-secrets-web/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ricoberger/sealed-secrets-web
-  tag: 2.1.5
+  tag: 2.2.0
   pullPolicy: IfNotPresent
   args: []
 

--- a/cmd/sealedsecretsweb/Dockerfile
+++ b/cmd/sealedsecretsweb/Dockerfile
@@ -9,7 +9,7 @@ LABEL git.version=$VERSION
 LABEL git.url="https://github.com/ricoberger/sealed-secrets-web"
 
 RUN apk add --no-cache --update curl ca-certificates
-RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.8.1/kubeseal-linux-amd64 -o /usr/local/bin/kubeseal
+RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.9.7/kubeseal-linux-amd64 -o /usr/local/bin/kubeseal
 RUN chmod +x /usr/local/bin/kubeseal
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD curl --fail http://localhost:8080/_health || exit 1
 

--- a/cmd/sealedsecretsweb/handler.go
+++ b/cmd/sealedsecretsweb/handler.go
@@ -39,7 +39,7 @@ func sealHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ss, err := secrets.Seal(data.Secret)
+	ss, err := secrets.Seal(data.Secret, *kubesealArgs)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("kubeseal error: %s", err.Error()), http.StatusBadRequest)
 		return

--- a/cmd/sealedsecretsweb/sealedsecretsweb.go
+++ b/cmd/sealedsecretsweb/sealedsecretsweb.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bitnami-labs/flagenv"
 	"github.com/bitnami-labs/pflagenv"
 	flag "github.com/spf13/pflag"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -24,10 +23,8 @@ const (
 )
 
 var (
-	certFile       = flag.String("cert", "", "Certificate / public key to use for encryption. Overrides --controller-*")
-	controllerNs   = flag.String("controller-namespace", metav1.NamespaceSystem, "Namespace of sealed-secrets controller.")
-	controllerName = flag.String("controller-name", "sealed-secrets-controller", "Name of sealed-secrets controller.")
 	disableLoadSecrets = flag.Bool("disable-load-secrets", false, "Disable the loading of existing secrets")
+	kubesealArgs   = flag.String("kubeseal-arguments", "", "Arguments which are passed to kubeseal")
 	outputFormat   = flag.String("format", "json", "Output format for sealed secret. Either json or yaml")
 	printVersion   = flag.Bool("version", false, "Print version information and exit")
 
@@ -45,7 +42,7 @@ func init() {
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := clientcmd.ConfigOverrides{}
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
-	flag.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
+	flag.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster")
 	clientcmd.BindOverrideFlags(&overrides, flag.CommandLine, kflags)
 	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 

--- a/pkg/secrets/seal.go
+++ b/pkg/secrets/seal.go
@@ -2,13 +2,14 @@ package secrets
 
 import (
 	"io"
-	"os"
 	"os/exec"
+	"strings"
 )
 
 // Seal runs the kubeseal client to create the sealed secret.
-func Seal(secret string) ([]byte, error) {
-	cmd := exec.Command("kubeseal", os.Args[1:]...)
+func Seal(secret string, kubesealArgs string) ([]byte, error) {
+	args := strings.Split(kubesealArgs, " ")
+	cmd := exec.Command("kubeseal", args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A new flag `kubeseal-arguments` is introduced, which can be used to pass arguments to kubeseal. We are not passing the arguments from the `sealed-secrets-web` directly to the underlying kubeseal.

Example values file for the Helm chart:

```yaml
image:
  repository: ricoberger/sealed-secrets-web
  tag: 2.2.0
  pullPolicy: IfNotPresent
  args:
    - --format=yaml
    - --kubeseal-arguments=--format yaml --controller-name sealed-secrets
    - --disable-load-secrets
```

These arguments disable the loading of secrets, use yaml format for the web interface and for kubeseal and change the controller name for sealed secrets.

Fixes #7 