### PR TITLE
reduce image size

### DIFF
--- a/cmd/sealedsecretsweb/Dockerfile
+++ b/cmd/sealedsecretsweb/Dockerfile
@@ -3,14 +3,17 @@ FROM alpine:latest
 ARG REVISION
 ARG VERSION
 
-LABEL maintainer="Rico Berger"
-LABEL git.ref=$REVISION
-LABEL git.version=$VERSION
-LABEL git.url="https://github.com/ricoberger/sealed-secrets-web"
+LABEL maintainer="Rico Berger" \
+      git.ref=$REVISION \
+      git.version=$VERSION \
+      git.url="https://github.com/ricoberger/sealed-secrets-web"
 
-RUN apk add --no-cache --update curl ca-certificates
-RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/kubeseal-linux-amd64 -o /usr/local/bin/kubeseal
-RUN chmod +x /usr/local/bin/kubeseal
+ENV KUBESEAL_VERSION=v0.16.0
+
+RUN apk add --no-cache --update curl ca-certificates && \
+    curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/${KUBESEAL_VERSION}/kubeseal-linux-amd64 -o /usr/local/bin/kubeseal && \
+    chmod +x /usr/local/bin/kubeseal \
+
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD curl --fail http://localhost:8080/_health || exit 1
 
 RUN addgroup -g 1000 sealedsecretsweb && \


### PR DESCRIPTION
When downloading the latest image I saw, that 2 layers with the same size got downloaded, this is because kubeseal was downloaded and chmod-ed in two different layers.
Like that the size of kubeseal adds twice to the total image size.

This PR adds the commands in one RUN step to fix this issue.
Also Labels are consolidated into one image layer.

Since this does not change anything in the functionality of this application, there is no need to immediately create a new release.